### PR TITLE
Use 2.6 release branches for typetree and functions

### DIFF
--- a/dune-2.6/Dockerfile
+++ b/dune-2.6/Dockerfile
@@ -8,5 +8,5 @@ RUN duneci-install-module -b releases/2.6 https://gitlab.dune-project.org/core/d
   && duneci-install-module -b releases/2.6 https://gitlab.dune-project.org/core/dune-grid.git \
   && duneci-install-module -b releases/2.6 https://gitlab.dune-project.org/core/dune-istl.git \
   && duneci-install-module -b releases/2.6 https://gitlab.dune-project.org/core/dune-localfunctions.git \
-  && duneci-install-module https://gitlab.dune-project.org/staging/dune-typetree.git \
-  && duneci-install-module https://gitlab.dune-project.org/staging/dune-functions.git
+  && duneci-install-module -b releases/2.6 https://gitlab.dune-project.org/staging/dune-typetree.git \
+  && duneci-install-module -b releases/2.6 https://gitlab.dune-project.org/staging/dune-functions.git


### PR DESCRIPTION
There are now 2.6 release branches for those two modules, so use them.