### PR TITLE
Bump base-10 image to clang 5

### DIFF
--- a/base-10/Dockerfile
+++ b/base-10/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get dist-upgrade --no-install-recommends --yes \
   bison \
   build-essential \
   ca-certificates \
-  clang-4.0 \
+  clang-5.0 \
   cmake \
   coinor-libipopt-dev \
   curl \

--- a/base-10/opts.clang
+++ b/base-10/opts.clang
@@ -1,1 +1,1 @@
-CMAKE_FLAGS="-DCMAKE_CXX_COMPILER=/usr/bin/clang++-4.0 -DCMAKE_C_COMPILER=/usr/bin/clang-4.0 -DCXX_MAX_STANDARD=17 -DCMAKE_CXX_FLAGS='-O2 -g -Wall -fcolor-diagnostics -ftemplate-backtrace-limit=0' ${DUNECI_PARALLEL:+-DDUNE_MAX_TEST_CORES=${DUNECI_PARALLEL}}"
+CMAKE_FLAGS="-DCMAKE_CXX_COMPILER=/usr/bin/clang++-5.0 -DCMAKE_C_COMPILER=/usr/bin/clang-5.0 -DCXX_MAX_STANDARD=17 -DCMAKE_CXX_FLAGS='-O2 -g -Wall -fcolor-diagnostics -ftemplate-backtrace-limit=0' ${DUNECI_PARALLEL:+-DDUNE_MAX_TEST_CORES=${DUNECI_PARALLEL}}"


### PR DESCRIPTION
The base-10 image is currently using clang 4, which has major compatibility issues with the stdlib
of GCC 7 in C++17 mode, mostly revolving around std::string_view. This makes it impossible to use
the clang in this image for compiling Dune.

This patch resolves the issue by simply bumping clang to version 5.

This resolves #5.